### PR TITLE
Refactor mongodb option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/iiinsomnia/yiigo
 go 1.12
 
 require (
+	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
 	github.com/go-sql-driver/mysql v1.4.1-0.20190510102335-877a9775f068
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/golang/protobuf v1.3.1 // indirect
@@ -14,6 +15,9 @@ require (
 	github.com/opentracing/opentracing-go v1.1.0 // indirect
 	github.com/pelletier/go-toml v1.4.1-0.20190530035549-dba45d427ff4
 	github.com/pkg/errors v0.8.1 // indirect
+	github.com/stretchr/testify v1.3.0 // indirect
+	github.com/tidwall/pretty v1.0.0 // indirect
+	github.com/uber-go/atomic v1.4.0 // indirect
 	github.com/uber/jaeger-client-go v2.16.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.0.0+incompatible // indirect
 	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c // indirect
@@ -25,6 +29,7 @@ require (
 	golang.org/x/net v0.0.0-20190603091049-60506f45cf65 // indirect
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58 // indirect
 	google.golang.org/grpc v1.21.0 // indirect
+	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0-20170531160350-a96e63847dc3
 	vitess.io/vitess v3.0.0-rc.3.0.20190602171040-12bfde34629c+incompatible

--- a/mongo.go
+++ b/mongo.go
@@ -17,7 +17,9 @@ import (
 // Mode indicates the user's preference on reads.
 type Mode int
 
+// Define Mode ENUM value
 const (
+	ErrMode            Mode = 0 // error mode, and will not set the mode value
 	Primary            Mode = 1 // Default mode. All operations read from the current replica set primary.
 	PrimaryPreferred   Mode = 2 // Read from the primary if available. Read from the secondary otherwise.
 	Secondary          Mode = 3 // Read from one of the nearest secondary members of the replica set.
@@ -28,7 +30,9 @@ const (
 // Concern for replica sets and replica set shards determines which data to return from a query.
 type Concern int
 
+// Define Concern ENUM value
 const (
+	ErrConcern   Concern = 0 // error concern, and will do not set the concern value
 	Local        Concern = 1 // the query should return the instance’s most recent data.
 	Available    Concern = 2 // the query should return data from the instance with no guarantee that the data has been written to a majority of the replica set members (i.e. may be rolled back).
 	Majority     Concern = 3 // the query should return the instance’s most recent data acknowledged as having been written to a majority of members in the replica set.
@@ -58,55 +62,40 @@ type mongoOptions struct {
 }
 
 // MongoOption configures how we set up the mongo
-type MongoOption interface {
-	apply(options *mongoOptions)
-}
-
-// funcMongoOption implements mongo option
-type funcMongoOption struct {
-	f func(options *mongoOptions)
-}
-
-func (fo *funcMongoOption) apply(o *mongoOptions) {
-	fo.f(o)
-}
-
-func newFuncMongoOption(f func(options *mongoOptions)) *funcMongoOption {
-	return &funcMongoOption{f: f}
-}
+type MongoOption func(options *mongoOptions)
 
 // WithMongoAppName specifies the `AppName` to mongo.
 // AppName sets the client application name.
 // This value is used by MongoDB when it logs connection information and profile information, such as slow queries.
 func WithMongoAppName(s string) MongoOption {
-	return newFuncMongoOption(func(o *mongoOptions) {
+	return func(o *mongoOptions) {
 		o.appName = s
-	})
+	}
 }
 
 // WithMongoConnTimeout specifies the `ConnTimeout` to mongo.
 // ConnectTimeout sets the timeout for an initial connection to a server.
 func WithMongoConnTimeout(d time.Duration) MongoOption {
-	return newFuncMongoOption(func(o *mongoOptions) {
+	return func(o *mongoOptions) {
 		o.connTimeout = d
-	})
+	}
 }
 
 // WithMongoPoolSize specifies the `PoolSize` to mongo.
 // MaxPoolSize sets the max size of a server's connection pool.
 func WithMongoPoolSize(n int) MongoOption {
-	return newFuncMongoOption(func(o *mongoOptions) {
+	return func(o *mongoOptions) {
 		o.poolSize = n
-	})
+	}
 }
 
 // WithMongoMaxConnIdleTime specifies the `MaxConnIdleTime` to mongo.
 // MaxConnIdleTime sets the maximum number of milliseconds that a connection can remain idle
 // in a connection pool before being removed and closed.
 func WithMongoMaxConnIdleTime(d time.Duration) MongoOption {
-	return newFuncMongoOption(func(o *mongoOptions) {
+	return func(o *mongoOptions) {
 		o.maxConnIdleTime = d
-	})
+	}
 }
 
 // WithMongoLocalThreshold specifies the `LocalThreshold` to mongo.
@@ -114,115 +103,115 @@ func WithMongoMaxConnIdleTime(d time.Duration) MongoOption {
 // round-trip time. If a server's roundtrip time is more than LocalThreshold slower than the
 // the fastest, the driver will not send queries to that server.
 func WithMongoLocalThreshold(d time.Duration) MongoOption {
-	return newFuncMongoOption(func(o *mongoOptions) {
+	return func(o *mongoOptions) {
 		o.localThreshold = d
-	})
+	}
 }
 
 // WithMongoServerSelectionTimeout specifies the `ServerSelectionTimeout` to mongo.
 // ServerSelectionTimeout sets a timeout in milliseconds to block for server selection.
 func WithMongoServerSelectionTimeout(d time.Duration) MongoOption {
-	return newFuncMongoOption(func(o *mongoOptions) {
+	return func(o *mongoOptions) {
 		o.serverSelectionTimeout = d
-	})
+	}
 }
 
 // WithMongoSocketTimeout specifies the `SocketTimeout` to mongo.
 // SocketTimeout sets the time in milliseconds to attempt to send or receive on a socket
 // before the attempt times out.
 func WithMongoSocketTimeout(d time.Duration) MongoOption {
-	return newFuncMongoOption(func(o *mongoOptions) {
+	return func(o *mongoOptions) {
 		o.socketTimeout = d
-	})
+	}
 }
 
 // WithMongoHeartbeatInterval specifies the `HeartbeatInterval` to mongo.
 // HeartbeatInterval sets the interval to wait between server monitoring checks.
 func WithMongoHeartbeatInterval(d time.Duration) MongoOption {
-	return newFuncMongoOption(func(o *mongoOptions) {
+	return func(o *mongoOptions) {
 		o.heartbeatInterval = d
-	})
+	}
 }
 
 // WithMongoCompressors specifies the `Compressors` to mongo.
 // Compressors sets the compressors that can be used when communicating with a server.
 func WithMongoCompressors(s ...string) MongoOption {
-	return newFuncMongoOption(func(o *mongoOptions) {
+	return func(o *mongoOptions) {
 		o.compressors = s
-	})
+	}
 }
 
 // WithMongoHosts specifies the `Hosts` to mongo.
 // Hosts sets the initial list of addresses from which to discover the rest of the cluster.
 func WithMongoHosts(s ...string) MongoOption {
-	return newFuncMongoOption(func(o *mongoOptions) {
+	return func(o *mongoOptions) {
 		o.hosts = s
-	})
+	}
 }
 
 // WithMongoReplicaSet specifies the `ReplicaSet` to mongo.
 // ReplicaSet sets the name of the replica set of the cluster.
 func WithMongoReplicaSet(s string) MongoOption {
-	return newFuncMongoOption(func(o *mongoOptions) {
+	return func(o *mongoOptions) {
 		o.replicaSet = s
-	})
+	}
 }
 
 // WithMongoRetryWrites specifies the `RetryWrites` to mongo.
 // RetryWrites sets whether the client has retryable writes enabled.
 func WithMongoRetryWrites(b bool) MongoOption {
-	return newFuncMongoOption(func(o *mongoOptions) {
+	return func(o *mongoOptions) {
 		o.retryWrites = b
-	})
+	}
 }
 
 // WithMongoDirect specifies the `Direct` to mongo.
 // Direct sets whether the driver should connect directly to the server instead of
 // auto-discovering other servers in the cluster.
 func WithMongoDirect(b bool) MongoOption {
-	return newFuncMongoOption(func(o *mongoOptions) {
+	return func(o *mongoOptions) {
 		o.direct = b
-	})
+	}
 }
 
 // WithMongoMode specifies the `Mode` to mongo.
 // Mode sets the read preference.
 func WithMongoMode(m Mode) MongoOption {
-	return newFuncMongoOption(func(o *mongoOptions) {
+	return func(o *mongoOptions) {
 		o.mode = m
-	})
+	}
 }
 
 // WithMongoReadConcern specifies the `ReadConcern` to mongo.
 // ReadConcern sets the read concern.
 func WithMongoReadConcern(c Concern) MongoOption {
-	return newFuncMongoOption(func(o *mongoOptions) {
+	return func(o *mongoOptions) {
 		o.readConcern = c
-	})
+	}
 }
 
 // WithMongoWriteConcern specifies the `WriteConcern` to mongo.
 // WriteConcern sets the write concern.
 func WithMongoWriteConcern(c ...writeconcern.Option) MongoOption {
-	return newFuncMongoOption(func(o *mongoOptions) {
+	return func(o *mongoOptions) {
 		o.writeConcern = c
-	})
+	}
 }
 
 // WithMongoTLSConfig specifies the `TLSConfig` to mongo.
 // SetTLSConfig sets the tls.Config.
 func WithMongoTLSConfig(c *tls.Config) MongoOption {
-	return newFuncMongoOption(func(o *mongoOptions) {
+	return func(o *mongoOptions) {
 		o.tlsConfig = c
-	})
+	}
 }
 
 // WithMongoZlibLevel specifies the `ZlibLevel` to mongo.
 // ZlibLevel sets the level for the zlib compressor.
 func WithMongoZlibLevel(l int) MongoOption {
-	return newFuncMongoOption(func(o *mongoOptions) {
+	return func(o *mongoOptions) {
 		o.zlibLevel = l
-	})
+	}
 }
 
 var (
@@ -238,10 +227,8 @@ func mongoDial(dsn string, mgoOptions ...MongoOption) (*mongo.Client, error) {
 		maxConnIdleTime: 60 * time.Second,
 	}
 
-	if len(mgoOptions) > 0 {
-		for _, option := range mgoOptions {
-			option.apply(o)
-		}
+	for _, option := range mgoOptions {
+		option(o)
 	}
 
 	clientOptions := options.Client()
@@ -291,7 +278,7 @@ func mongoDial(dsn string, mgoOptions ...MongoOption) (*mongo.Client, error) {
 		clientOptions.SetDirect(true)
 	}
 
-	if o.mode != 0 {
+	if o.mode != ErrMode {
 		switch o.mode {
 		case Primary:
 			clientOptions.SetReadPreference(readpref.Primary())
@@ -306,7 +293,7 @@ func mongoDial(dsn string, mgoOptions ...MongoOption) (*mongo.Client, error) {
 		}
 	}
 
-	if o.readConcern != 0 {
+	if o.readConcern != ErrConcern {
 		switch o.readConcern {
 		case Local:
 			clientOptions.SetReadConcern(readconcern.Local())
@@ -338,7 +325,9 @@ func mongoDial(dsn string, mgoOptions ...MongoOption) (*mongo.Client, error) {
 		return nil, err
 	}
 
-	ctx, _ := context.WithTimeout(context.TODO(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+	defer cancel()
+
 	client, err := mongo.Connect(ctx, clientOptions)
 
 	return client, err


### PR DESCRIPTION
Hi @iiinsomnia ,
I'm glad to use this powerful package, but I prefer to use function instead of interface to handle the mongodb configuration, and waiting for you kindly reply. 

Before:
```go
// definition
type MongoOption interface {
	apply(options *mongoOptions)	
}
// using
for _, option := range mgoOptions {
	option.apply(o)	
}
```

After
```go
// definition
type MongoOption func(options *mongoOptions)
// using
for _, option := range mgoOptions {
	option(o)
}
```

Purpose: **Less code, easier understand**